### PR TITLE
Changed company's individual listings

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,6 +16,9 @@
 * {
 	outline: none;
 }
+a {
+	text-decoration: none !important;
+}
 
 button {
 	outline: none !important;
@@ -412,6 +415,10 @@ body {
 
 .not-a-member {
 	color: #0056b3;
+
+}
+.card-title:hover {
+	text-decoration: none !important;
 
 }
 .not-a-member:hover {

--- a/app/views/employers_profiles/show.html.erb
+++ b/app/views/employers_profiles/show.html.erb
@@ -18,23 +18,15 @@
             </div>
           </div>
           <div class="card-body">
-            <h5 class="card-title">
-              <%= card.job_title %>
-            </h5>
+
+            <a href="/listings/<%= card.id%>"><h5 class="card-title">
+										<%= card.job_title %>
+								</h5></a>
             <p class="listing-small-description">
               <%= card.description %>
             </p>
           </div>
-          <div class="card-body">
-            <a class="card-link">
-              <%= link_to 'Show',listing_path(card) %></a>
-            <a class="card-link">
-              <%= link_to 'Edit', edit_listing_path(card) %></a>
-            <a class="card-link">
-              <%= link_to 'Destroy', listing_path(card),
-				method: :delete,
-				data: { confirm: 'Are you sure?' } %></a>
-          </div>
+
         </div>
       <%end%>
     </div>

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -15,7 +15,14 @@
 				<strong>What you’ll be doing</strong><br/>
 				<%= @listing.description %>
 		</p>
-		<%= link_to 'Back To Dashboard', listings_path %>
+		<%= link_to 'Back To Dashboard', listings_path %> |
+		 <%= link_to 'Edit Listing', edit_listing_path %> |
+		   <%= link_to 'Remove Listing', listing_path,
+				method: :delete,
+				data: { confirm: 'Are you sure?' } %>
+
 		<br/>
+		<% if current_explorer %>
 		<a href="/interest/<%=@listing.id%>/<%=@explorers_profile.id%>">Register Interest</a>
+		<% end %>
 </div>


### PR DESCRIPTION
Removed the links for "Show" "Edit" "Destroy" from company's dashboard listings cards. Moved them into the individual listing page for the company to edit or delete the post from there.
Changed the card title of the grid with listings to link to the individual post.